### PR TITLE
Notifications update

### DIFF
--- a/api/src/database/migrations/20221025A-add-notifications-read.ts
+++ b/api/src/database/migrations/20221025A-add-notifications-read.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_notifications', (table) => {
+		table.boolean('read').defaultTo(false);
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_notifications', (table) => {
+		table.dropColumn('read');
+	});
+}

--- a/api/src/database/system-data/fields/notifications.yaml
+++ b/api/src/database/system-data/fields/notifications.yaml
@@ -13,3 +13,4 @@ fields:
   - field: message
   - field: collection
   - field: item
+  - field: read

--- a/app/src/stores/notifications.ts
+++ b/app/src/stores/notifications.ts
@@ -42,6 +42,11 @@ export const useNotificationsStore = defineStore({
 									_eq: 'inbox',
 								},
 							},
+							{
+								read: {
+									_eq: false,
+								},
+							},
 						],
 					},
 					aggregate: {

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -90,7 +90,6 @@ import { storeToRefs } from 'pinia';
 import { Notification } from '@directus/shared/types';
 import api from '@/api';
 import { Header as TableHeader } from '@/components/v-table/types';
-import { Item } from '@directus/shared/types';
 import { useRouter } from 'vue-router';
 import { parseISO } from 'date-fns';
 import { localizedFormatDistance } from '@/utils/localized-format-distance';

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -16,6 +16,9 @@
 			>
 				<v-icon :name="tab[0] === 'inbox' ? 'archive' : 'move_to_inbox'" />
 			</v-button>
+			<v-button icon rounded :disabled="selection.length === 0" secondary @click="markUnread">
+				<v-icon name="mark_email_unread" />
+			</v-button>
 		</template>
 
 		<template #sidebar>
@@ -49,7 +52,7 @@
 			item-key="id"
 			@click:row="onRowClick"
 		>
-			<template #[`#item.read`]="{ item }">
+			<template #[`item.read`]="{ item }">
 				<v-badge dot :class="{ read: item.read }" />
 			</template>
 		</v-table>
@@ -162,6 +165,7 @@ export default defineComponent({
 			tab,
 			notificationDetailDrawerOpen,
 			viewingNotification,
+			markUnread,
 		};
 
 		async function fetchNotifications() {
@@ -245,6 +249,20 @@ export default defineComponent({
 			}
 			// Set viewed notification as read
 			await api.patch(`/notifications/${item.id}`, { read: true });
+			await fetchNotifications();
+		}
+
+		async function markUnread() {
+			await api.patch('/notifications', {
+				keys: selection.value.map(({ id }) => id),
+				data: {
+					read: false,
+				},
+			});
+
+			await fetchNotifications();
+
+			selection.value = [];
 		}
 	},
 });

--- a/packages/shared/src/types/notifications.ts
+++ b/packages/shared/src/types/notifications.ts
@@ -10,4 +10,5 @@ export type Notification = {
 	message: string | null;
 	collection: string | null;
 	item: PrimaryKey | null;
+	read: boolean;
 };


### PR DESCRIPTION
## Update the notification system to provide new functionality and fix a bug.

This update addresses the issue outlined here: https://github.com/directus/directus/issues/13727 but also provides some improvements around the notification system as a whole. 

- Notifications now have a 'read' property to indicate whether a notification has been viewed or not
- The notification badge in the navigation bar will now reflect the number of unread messages, as opposed to all messages in the inbox
- If a notification comes from a collection comment, the user will still be redirected to that collection. Otherwise, they can click a notification to see the detail message associated with it. This is the scenario when notifications are sent as a result of a flow/operation. 

Fixes #

## Type of Change

- [x] Bugfix
- [x] Improvement
- [ ] New Feature
- [ ] Refactor / codestyle updates
- [ ] Other, please describe:

## Requirements Checklist

- [ ] New / updated tests are included
- [x] All tests are passing locally
- [x] Performed a self-review of the submitted code

If adding a new feature:

- [ ] Documentation was added/updated. PR: 
